### PR TITLE
feat: add Qiniu provider support

### DIFF
--- a/src/main/assets/config/llm.json
+++ b/src/main/assets/config/llm.json
@@ -59,6 +59,15 @@
       "modelList": ["deepseek-chat"]
     },
     {
+      "url": "https://api.qnaigc.com",
+      "urlList": ["https://api.qnaigc.com"],
+      "path": "/v1/chat/completions",
+      "name": "Qiniu",
+      "icon": "https://www.qiniu.com/favicon.ico",
+      "model": "deepseek-v3",
+      "modelList": ["deepseek-v3"]
+    },
+    {
       "url": "https://api.openai.com",
       "urlList": ["https://api.openai.com", "https://api.aiql.com"],
       "name": "OpenAI & Proxy",


### PR DESCRIPTION
## Summary
Added support for Qiniu AI (七牛云) as a new model provider.

## What changed

- `src/main/assets/config/llm.json` - Registers Qiniu (七牛云) as a custom LLM preset with gateway URL, path, default model, and icon.

## Testing

```
npx vue-tsc --noEmit && npx vite build && npx playwright test tests --reporter=list
# 2 passed 0 failed
```


## Result
<img width="2879" height="1169" alt="屏幕截图 2026-05-13 110939" src="https://github.com/user-attachments/assets/0f132722-2552-4d5b-b2b3-169ca22a4291" />

---

<img width="2838" height="1575" alt="屏幕截图 2026-05-13 110932" src="https://github.com/user-attachments/assets/d53e8968-99d2-4f41-a2e6-d8e36b124c72" />
